### PR TITLE
Fixed content-type of POST requests

### DIFF
--- a/lib/teamwork.coffee
+++ b/lib/teamwork.coffee
@@ -298,7 +298,7 @@ class Teamworker
     if typeof argsOrCallback is 'function'
       return @request(options, argsOrCallback)
 
-    options.form = JSON.stringify(argsOrCallback)
+    options.json = argsOrCallback
 
     @request(options, callback)
 


### PR DESCRIPTION
Teamwork no longer accepts `application/x-www-form-urlencoded` post requests. This already indicates the content should be sent json encoded, but setting the value on form causes it to instead submit as `application/x-www-form-urlencoded`. As a result, there is no response from Teamwork.
